### PR TITLE
encode _links/_embedded properly in requests

### DIFF
--- a/lib/dwolla/utils.ex
+++ b/lib/dwolla/utils.ex
@@ -79,15 +79,23 @@ defmodule Dwolla.Utils do
     |> Stream.map(fn {k, v} -> {to_string(k), v} end)
     |> Stream.map(fn {k, v} ->
         if is_map(v) do
-          {Recase.to_camel(k), to_camel_case(v)}
+          {key_to_camel_case(k), to_camel_case(v)}
         else
-          {Recase.to_camel(k), v}
+          {key_to_camel_case(k), v}
         end
       end)
     |> Enum.into(%{})
   end
   def to_camel_case(payload) do
     payload
+  end
+
+  defp key_to_camel_case(k) when k in ["_links", "_embedded"] do
+    k
+  end
+
+  defp key_to_camel_case(k) do
+    Recase.to_camel(k)
   end
 
   @doc """

--- a/test/lib/dwolla/utils_test.exs
+++ b/test/lib/dwolla/utils_test.exs
@@ -37,6 +37,12 @@ defmodule Dwolla.UtilsTest do
 
     test "to_camel_case/1 converts atom keys to camel case" do
       params = %{
+        _links: %{
+          foo: "bar"
+        },
+        _embedded: %{
+          baz: "qux"
+        },
         first_name: "Steve",
         last_name: "Rogers",
         date_of_birth: "1918-07-04",
@@ -47,6 +53,12 @@ defmodule Dwolla.UtilsTest do
       }
 
       assert Utils.to_camel_case(params) == %{
+        "_links" => %{
+          "foo" => "bar"
+        },
+        "_embedded" => %{
+          "baz" => "qux"
+        },
         "firstName" => "Steve",
         "lastName" => "Rogers",
         "dateOfBirth" => "1918-07-04",


### PR DESCRIPTION
e.g. to support initiate transfer which returns error when `_links` is transformed to `links`