### PR TITLE
fix: Remove ip_address as a required param

### DIFF
--- a/lib/dwolla/customer.ex
+++ b/lib/dwolla/customer.ex
@@ -31,7 +31,7 @@ defmodule Dwolla.Customer do
 
   @endpoint "customers"
 
-  @unverified_customer ["first_name", "last_name", "email", "ip_address"]
+  @unverified_customer ["first_name", "last_name", "email"]
 
   @verified_customer   @unverified_customer ++ ["type", "address1", "city",
                        "state", "postal_code", "date_of_birth", "ssn"]


### PR DESCRIPTION
- Removes ip_address as a required param when creating a user

Per the dwolla documentation, this is not a required param for verified & unverified customers:  https://docs.dwolla.com/#customers

Tested this out with sandbox credentials and is working as intended